### PR TITLE
feat: capacitor splash screen not hiding on ios

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+<a name="1.9.2"></a>
+
+# 1.9.2 (2021-06-26)
+
+### Fix
+
+- Capacitor splashscreen not hiding on (real) iOS app
+
 <a name="1.9.1"></a>
 
 # 1.9.1 (2021-06-25)

--- a/android/app/src/main/assets/capacitor.config.json
+++ b/android/app/src/main/assets/capacitor.config.json
@@ -7,7 +7,6 @@
 	"cordova": {},
 	"plugins": {
 		"SplashScreen": {
-			"launchAutoHide": false,
 			"androidScaleType": "CENTER_CROP"
 		}
 	}

--- a/capacitor.config.json
+++ b/capacitor.config.json
@@ -7,7 +7,6 @@
   "cordova": {},
   "plugins": {
     "SplashScreen": {
-      "launchAutoHide": false,
       "androidScaleType": "CENTER_CROP"
     }
   }

--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -350,7 +350,7 @@
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 1.9.0;
+				MARKETING_VERSION = 1.9.2;
 				OTHER_SWIFT_FLAGS = "$(inherited) \"-D\" \"COCOAPODS\" \"-DDEBUG\"";
 				PRODUCT_BUNDLE_IDENTIFIER = com.tietracker.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -370,7 +370,7 @@
 				INFOPLIST_FILE = App/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 12.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				MARKETING_VERSION = 1.9.0;
+				MARKETING_VERSION = 1.9.2;
 				PRODUCT_BUNDLE_IDENTIFIER = com.tietracker.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "";

--- a/ios/App/App/Info.plist
+++ b/ios/App/App/Info.plist
@@ -5,7 +5,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleDisplayName</key>
-        <string>Tie Tracker</string>
+	<string>Tie Tracker</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>

--- a/ios/App/App/capacitor.config.json
+++ b/ios/App/App/capacitor.config.json
@@ -7,7 +7,6 @@
 	"cordova": {},
 	"plugins": {
 		"SplashScreen": {
-			"launchAutoHide": false,
 			"androidScaleType": "CENTER_CROP"
 		}
 	}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,8 +7,6 @@ import {Translation} from 'react-i18next';
 
 import {options, card, information, statsChart} from 'ionicons/icons';
 
-import {SplashScreen} from '@capacitor/splash-screen';
-
 import Settings from './pages/settings/Settings';
 import Invoices from './pages/invoices/Invoices';
 import Statistics from './pages/statistics/Statistics';
@@ -77,8 +75,6 @@ const App: React.FC<RootProps> = (props: RootProps) => {
   async function init() {
     // Init theme first
     await props.initTheme();
-
-    await SplashScreen.hide();
 
     await initAllData(props);
   }


### PR DESCRIPTION
Uglier and less user friendly but, at least, hopefully the splash screen will become  hidden when used on real iOS app.